### PR TITLE
Use JSR repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 [![jsr](https://img.shields.io/jsr/v/%40lambdalisue/ansi-escape-code?logo=javascript&logoColor=white)](https://jsr.io/@lambdalisue/ansi-escape-code)
 [![denoland](https://img.shields.io/github/v/release/lambdalisue/deno-ansi-escape-code?logo=deno&label=denoland)](https://github.com/lambdalisue/deno-ansi-escape-code/releases)
-[![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/ansi_escape_code/mod.ts)
+[![deno doc](https://doc.deno.land/badge.svg)](https://jsr.io/@lambdalisue/ansi-escape-code/doc)
 [![Test](https://github.com/lambdalisue/deno-ansi-escape-code/workflows/Test/badge.svg)](https://github.com/lambdalisue/deno-ansi-escape-code/actions?query=workflow%3ATest)
 
 Utilities to trim and parse ANSI escape sequence.
 
-[deno]: https://deno.land/
+[Deno]: https://deno.land/
 
 ## Usage
 
 ```typescript
-import { assertEquals } from "https://deno.land/std@0.164.0/testing/asserts.ts";
-import { trimAndParse } from "https://deno.land/x/ansi_escape_code/mod.ts";
+import { assertEquals } from "jsr:@std/assert@1.0.2/equals";
+import { trimAndParse } from "jsr:@lambdalisue/ansi-escape-code";
 
 const [trimmed, annotations] = trimAndParse(
   "\x1b[1mHe\x1b[30mll\x1b[31mo\x1b[m world",

--- a/csi_test.ts
+++ b/csi_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "jsr:@std/assert@1.0.2/equals";
 import { type Csi, parseCsi } from "./csi.ts";
 
 Deno.test("parseCsi", async (t) => {

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -6,6 +6,6 @@
   "tasks": {
     "test": "deno test --unstable -A --parallel",
     "check": "deno check --unstable $(find . -name '*.ts')",
-    "upgrade": "deno run -A https://deno.land/x/udd/main.ts $(find . -name '*.ts')"
+    "upgrade": "deno run -A jsr:@molt/cli **/*.ts --write"
   }
 }

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "jsr:@std/assert@1.0.2/equals";
 import { type Annotation, trimAndParse } from "./parser.ts";
 
 Deno.test("trimAndParse", async (t) => {

--- a/sgr_test.ts
+++ b/sgr_test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.186.0/testing/asserts.ts";
+import { assertEquals } from "jsr:@std/assert@1.0.2/equals";
+
 import { parseSgr, type Sgr } from "./sgr.ts";
 
 Deno.test("parseSgr", async (t) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README to use jsr.io URLs for documentation badges and usage examples.
  - Capitalized the "Deno" reference in the README.

- **Chores**
  - Updated test imports to use jsr.io module paths instead of Deno standard library URLs.
  - Modified the upgrade task configuration to use a new module source and options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->