### PR TITLE
Add parseWithText()

### DIFF
--- a/parser.ts
+++ b/parser.ts
@@ -4,8 +4,13 @@ const patternCsiGlobal = new RegExp(patternCsi, "g");
 
 export type Annotation = {
   offset: number;
-  csi: Csi;
   raw: string;
+  csi: Csi;
+};
+
+export type AnnotationText = {
+  offset: number;
+  text: string;
 };
 
 /**
@@ -26,4 +31,49 @@ export function trimAndParse(expr: string): [string, Annotation[]] {
     }
   }
   return [expr.replaceAll(patternCsiGlobal, ""), annotations];
+}
+
+/**
+ * Parse ANSI escape code in `expr` and return it.
+ * The function keeps both text output and annotations in the result.
+ */
+export function parseWithText(expr: string): (Annotation | AnnotationText)[] {
+  const annotations: (Annotation | AnnotationText)[] = [];
+  let currentOffset = 0;
+  let adjustedOffset = 0;
+
+  for (const match of expr.matchAll(patternCsiGlobal)) {
+    const matchStart = match.index ?? 0;
+    const matchEnd = matchStart + (match[0]?.length ?? 0);
+
+    // Add the plain text before the match as a text annotation
+    if (currentOffset < matchStart) {
+      const textPart = expr.slice(currentOffset, matchStart);
+      annotations.push({
+        offset: adjustedOffset,
+        text: textPart,
+      });
+      adjustedOffset += textPart.length; // Add text length
+    }
+
+    // Add the matched ANSI escape sequence
+    annotations.push({
+      offset: adjustedOffset,
+      csi: parseCsi(match[0]!),
+      raw: match[0]!,
+    });
+
+    currentOffset = matchEnd;
+  }
+
+  // Add the remaining text after the last match as a text annotation
+  if (currentOffset < expr.length) {
+    const textPart = expr.slice(currentOffset);
+    annotations.push({
+      offset: adjustedOffset,
+      text: textPart,
+    });
+  }
+
+  return annotations;
 }

--- a/parser.ts
+++ b/parser.ts
@@ -4,8 +4,8 @@ const patternCsiGlobal = new RegExp(patternCsi, "g");
 
 export type Annotation = {
   offset: number;
-  raw: string;
   csi: Csi;
+  raw: string;
 };
 
 export type AnnotationText = {

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "jsr:@std/assert@1.0.2/equals";
-import { type Annotation, trimAndParse } from "./parser.ts";
+import {
+  type Annotation,
+  type AnnotationText,
+  parseWithText,
+  trimAndParse,
+} from "./parser.ts";
 
 Deno.test("trimAndParse", async (t) => {
   const testcases: [string, [string, Annotation[]]][] = [
@@ -52,6 +57,139 @@ Deno.test("trimAndParse", async (t) => {
   for (const [expr, expected] of testcases) {
     await t.step(`properly handle "${expr}"`, () => {
       const actual = trimAndParse(expr);
+      assertEquals(actual, expected);
+    });
+  }
+});
+
+Deno.test("trimAndParse", async (t) => {
+  const testcases: [string, [string, Annotation[]]][] = [
+    ["Hello world", ["Hello world", []]],
+    ["\x1b[1mHello\x1b[m world", ["Hello world", [
+      { offset: 0, raw: "\x1b[1m", csi: { sgr: { bold: true } } },
+      { offset: 5, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+    ]]],
+    ["\x1b[1mHe\x1b[30mll\x1b[31mo\x1b[m world", ["Hello world", [
+      { offset: 0, raw: "\x1b[1m", csi: { sgr: { bold: true } } },
+      { offset: 2, raw: "\x1b[30m", csi: { sgr: { foreground: 0 } } },
+      { offset: 4, raw: "\x1b[31m", csi: { sgr: { foreground: 1 } } },
+      { offset: 5, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+    ]]],
+    ["\x1b[31mRed\x1b[m", [
+      "Red",
+      [
+        { offset: 0, raw: "\x1b[31m", csi: { sgr: { foreground: 1 } } },
+        { offset: 3, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ]],
+    ["\x1b[1;31mBright red (old)\x1b[m", [
+      "Bright red (old)",
+      [
+        {
+          offset: 0,
+          raw: "\x1b[1;31m",
+          csi: { sgr: { bold: true, foreground: 1 } },
+        },
+        { offset: 16, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ]],
+    ["\x1b[91mBright red (new)\x1b[m", [
+      "Bright red (new)",
+      [
+        { offset: 0, raw: "\x1b[91m", csi: { sgr: { foreground: 9 } } },
+        { offset: 16, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ]],
+    ["\x1b[32m|\x1b[m\x1b[33m\\\x1b[m", [
+      "|\\",
+      [
+        { offset: 0, raw: "\x1b[32m", csi: { sgr: { foreground: 2 } } },
+        { offset: 1, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+        { offset: 1, raw: "\x1b[33m", csi: { sgr: { foreground: 3 } } },
+        { offset: 2, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ]],
+  ];
+  for (const [expr, expected] of testcases) {
+    await t.step(`properly handle "${expr}"`, () => {
+      const actual = trimAndParse(expr);
+      assertEquals(actual, expected);
+    });
+  }
+});
+
+Deno.test("parseWithText", async (t) => {
+  const testcases: [string, (Annotation | AnnotationText)[]][] = [
+    [
+      "Hello world",
+      [{ offset: 0, text: "Hello world" }],
+    ],
+    [
+      "\x1b[1mHello\x1b[m world",
+      [
+        { offset: 0, raw: "\x1b[1m", csi: { sgr: { bold: true } } },
+        { offset: 0, text: "Hello" },
+        { offset: 5, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+        { offset: 5, text: " world" },
+      ],
+    ],
+    [
+      "\x1b[1mHe\x1b[30mll\x1b[31mo\x1b[m world",
+      [
+        { offset: 0, raw: "\x1b[1m", csi: { sgr: { bold: true } } },
+        { offset: 0, text: "He" },
+        { offset: 2, raw: "\x1b[30m", csi: { sgr: { foreground: 0 } } },
+        { offset: 2, text: "ll" },
+        { offset: 4, raw: "\x1b[31m", csi: { sgr: { foreground: 1 } } },
+        { offset: 4, text: "o" },
+        { offset: 5, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+        { offset: 5, text: " world" },
+      ],
+    ],
+    [
+      "\x1b[31mRed\x1b[m",
+      [
+        { offset: 0, raw: "\x1b[31m", csi: { sgr: { foreground: 1 } } },
+        { offset: 0, text: "Red" },
+        { offset: 3, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ],
+    [
+      "\x1b[1;31mBright red (old)\x1b[m",
+      [
+        {
+          offset: 0,
+          raw: "\x1b[1;31m",
+          csi: { sgr: { bold: true, foreground: 1 } },
+        },
+        { offset: 0, text: "Bright red (old)" },
+        { offset: 16, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ],
+    [
+      "\x1b[91mBright red (new)\x1b[m",
+      [
+        { offset: 0, raw: "\x1b[91m", csi: { sgr: { foreground: 9 } } },
+        { offset: 0, text: "Bright red (new)" },
+        { offset: 16, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ],
+    [
+      "\x1b[32m|\x1b[m\x1b[33m\\\x1b[m",
+      [
+        { offset: 0, raw: "\x1b[32m", csi: { sgr: { foreground: 2 } } },
+        { offset: 0, text: "|" },
+        { offset: 1, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+        { offset: 1, raw: "\x1b[33m", csi: { sgr: { foreground: 3 } } },
+        { offset: 1, text: "\\" },
+        { offset: 2, raw: "\x1b[m", csi: { sgr: { reset: true } } },
+      ],
+    ],
+  ];
+
+  for (const [expr, expected] of testcases) {
+    await t.step(`properly handle "${expr}"`, () => {
+      const actual = parseWithText(expr);
       assertEquals(actual, expected);
     });
   }


### PR DESCRIPTION
Fix #4 

プルリクエストを作ってみました。互換性が崩れてしまうのを防ぐため、別関数にしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for parsing strings with ANSI escape codes into structured segments, distinguishing between plain text and formatted annotations.
- **Tests**
  - Added comprehensive tests to ensure accurate parsing of text and ANSI sequences, including various formatting codes and correct offset handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->